### PR TITLE
Use the same Go version as Juju dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/canonical/jimm-go-sdk/v3
 
-go 1.22.3
+go 1.21
 
 require (
 	github.com/frankban/quicktest v1.14.6


### PR DESCRIPTION
# Description

This PR updates the go.mod to use the same Go toolchain version as Juju.
